### PR TITLE
Update shabang to use env's `python`

### DIFF
--- a/dux.py
+++ b/dux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (C) 2015 Chris Sivanich
 #


### PR DESCRIPTION
Changes shabang from `python2` -> `python` may affect some system somewhere? Dux should run on either version, but will test for a bit.
